### PR TITLE
Version 3.9.5 - Reconnect throttling

### DIFF
--- a/dist/farmbot.js
+++ b/dist/farmbot.js
@@ -9,6 +9,9 @@ var ERR_MISSING_MQTT = "MQTT SERVER MISSING FROM TOKEN";
 var ERR_MISSING_UUID = "MISSING_UUID";
 var ERR_TOKEN_PARSE = "Unable to parse token. Is it properly formatted?";
 var UUID = "uuid";
+// Prevents our error catcher from getting overwhelmed by failed
+// connection attempts
+var RECONNECT_THROTTLE = 45000;
 var Farmbot = (function () {
     function Farmbot(input) {
         var _this = this;
@@ -390,7 +393,8 @@ var Farmbot = (function () {
         var _a = that.getState(), uuid = _a.uuid, token = _a.token, mqttServer = _a.mqttServer, timeout = _a.timeout;
         that.client = mqtt_1.connect(mqttServer, {
             username: uuid,
-            password: token
+            password: token,
+            reconnectPeriod: RECONNECT_THROTTLE
         });
         that.client.subscribe(that.channel.toClient);
         that.client.subscribe(that.channel.logs);
@@ -408,6 +412,6 @@ var Farmbot = (function () {
     };
     return Farmbot;
 }());
-Farmbot.VERSION = "3.9.4";
+Farmbot.VERSION = "3.9.5";
 Farmbot.defaults = { speed: 800, timeout: 6000, secure: true };
 exports.Farmbot = Farmbot;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "farmbot",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "Farmbot Javascript client.",
   "scripts": {
     "build": "./build.sh"

--- a/src/farmbot.ts
+++ b/src/farmbot.ts
@@ -27,8 +27,12 @@ const UUID = "uuid";
 declare var atob: (i: string) => string;
 declare var global: any;
 
+// Prevents our error catcher from getting overwhelmed by failed
+// connection attempts
+const RECONNECT_THROTTLE = 45000;
+
 export class Farmbot {
-  static VERSION = "3.9.4";
+  static VERSION = "3.9.5";
   static defaults = { speed: 800, timeout: 6000, secure: true };
 
   /** Storage area for all event handlers */
@@ -441,7 +445,8 @@ export class Farmbot {
     let { uuid, token, mqttServer, timeout } = that.getState();
     that.client = connect(<string>mqttServer, {
       username: <string>uuid,
-      password: <string>token
+      password: <string>token,
+      reconnectPeriod: RECONNECT_THROTTLE
     }) as MqttClient;
     that.client.subscribe(that.channel.toClient);
     that.client.subscribe(that.channel.logs);


### PR DESCRIPTION
# What's New?

 * There has been a longstanding issue where MQTTjs was trying to reconnect too agressivly. This was flooding browsers (and error reporting tools) with error messages.