### PR TITLE
5.0.1-rc10: Track a `sent` event to monitor RPC attempts

### DIFF
--- a/dist/farmbot.js
+++ b/dist/farmbot.js
@@ -298,6 +298,7 @@ var Farmbot = (function () {
     Farmbot.prototype.publish = function (msg, important) {
         if (important === void 0) { important = true; }
         if (this.client) {
+            this.emit("sent", msg);
             /** SEE: https://github.com/mqttjs/MQTT.js#client */
             this.client.publish(this.channel.toDevice, JSON.stringify(msg));
         }
@@ -386,7 +387,7 @@ var Farmbot = (function () {
             that.client.once("connect", function () { return resolve(that); });
         });
     };
-    Farmbot.VERSION = "5.0.1-rc8";
+    Farmbot.VERSION = "5.0.1-rc10";
     Farmbot.defaults = { speed: 800, timeout: 15000, secure: true };
     return Farmbot;
 }());

--- a/doc/classes/_farmbot_.farmbot.html
+++ b/doc/classes/_farmbot_.farmbot.html
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L39">farmbot.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L39">farmbot.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">_events<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_interfaces_.dictionary.html" class="tsd-signature-type">Dictionary</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L37">farmbot.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L37">farmbot.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">_state<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#statetree" class="tsd-signature-type">StateTree</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L38">farmbot.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L38">farmbot.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,17 +212,17 @@
 					<div class="tsd-signature tsd-kind-icon">client<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MqttClient</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L39">farmbot.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L39">farmbot.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-static">
 					<a name="version" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> VERSION</h3>
-					<div class="tsd-signature tsd-kind-icon">VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;5.0.1-rc8&quot;</span></div>
+					<div class="tsd-signature tsd-kind-icon">VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;5.0.1-rc10&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L33">farmbot.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L33">farmbot.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L341">farmbot.ts:341</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L341">farmbot.ts:341</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -288,7 +288,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L55">farmbot.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L55">farmbot.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -305,7 +305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L399">farmbot.ts:399</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L400">farmbot.ts:400</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -336,7 +336,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L295">farmbot.ts:295</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L295">farmbot.ts:295</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -364,7 +364,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L127">farmbot.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L127">farmbot.ts:127</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L422">farmbot.ts:422</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L423">farmbot.ts:423</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -408,7 +408,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L305">farmbot.ts:305</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L305">farmbot.ts:305</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -442,7 +442,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L148">farmbot.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L148">farmbot.ts:148</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -465,7 +465,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L154">farmbot.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L154">farmbot.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -488,7 +488,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L327">farmbot.ts:327</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L327">farmbot.ts:327</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -514,7 +514,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L318">farmbot.ts:318</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L318">farmbot.ts:318</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -543,7 +543,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L164">farmbot.ts:164</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L164">farmbot.ts:164</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -574,7 +574,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L159">farmbot.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L159">farmbot.ts:159</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -602,7 +602,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L179">farmbot.ts:179</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L179">farmbot.ts:179</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -639,7 +639,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L72">farmbot.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L72">farmbot.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -661,7 +661,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L173">farmbot.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L173">farmbot.ts:173</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -697,7 +697,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L91">farmbot.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L91">farmbot.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -726,7 +726,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L184">farmbot.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L184">farmbot.ts:184</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -768,7 +768,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L200">farmbot.ts:200</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L200">farmbot.ts:200</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -810,7 +810,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L323">farmbot.ts:323</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L323">farmbot.ts:323</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -836,7 +836,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L117">farmbot.ts:117</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L117">farmbot.ts:117</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -858,7 +858,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L355">farmbot.ts:355</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L355">farmbot.ts:355</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -890,7 +890,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L219">farmbot.ts:219</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L219">farmbot.ts:219</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -922,7 +922,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L122">farmbot.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L122">farmbot.ts:122</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -944,7 +944,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L109">farmbot.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L109">farmbot.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -972,7 +972,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L140">farmbot.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L140">farmbot.ts:140</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Object</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -989,7 +989,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L134">farmbot.ts:134</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L134">farmbot.ts:134</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1011,7 +1011,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L370">farmbot.ts:370</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L371">farmbot.ts:371</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1041,7 +1041,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L79">farmbot.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L79">farmbot.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1080,7 +1080,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L267">farmbot.ts:267</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L267">farmbot.ts:267</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1109,7 +1109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L237">farmbot.ts:237</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L237">farmbot.ts:237</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1139,7 +1139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L230">farmbot.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L230">farmbot.ts:230</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1170,7 +1170,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L224">farmbot.ts:224</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L224">farmbot.ts:224</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1200,7 +1200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L212">farmbot.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L212">farmbot.ts:212</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1233,7 +1233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L280">farmbot.ts:280</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L280">farmbot.ts:280</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1261,7 +1261,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L101">farmbot.ts:101</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L101">farmbot.ts:101</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1290,7 +1290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L245">farmbot.ts:245</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L245">farmbot.ts:245</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1318,7 +1318,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L207">farmbot.ts:207</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L207">farmbot.ts:207</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1356,7 +1356,7 @@
 					<div class="tsd-signature tsd-kind-icon">defaults<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L34">farmbot.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L34">farmbot.ts:34</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1365,7 +1365,7 @@
 						<div class="tsd-signature tsd-kind-icon">secure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;true</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L34">farmbot.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L34">farmbot.ts:34</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -1375,7 +1375,7 @@
 						<div class="tsd-signature tsd-kind-icon">speed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;800</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L34">farmbot.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L34">farmbot.ts:34</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -1385,7 +1385,7 @@
 						<div class="tsd-signature tsd-kind-icon">timeout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;15000</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L34">farmbot.ts:34</a></li>
+								<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L34">farmbot.ts:34</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/doc/enums/_interfaces_.encoder.html
+++ b/doc/enums/_interfaces_.encoder.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">differential<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L88">interfaces.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L88">interfaces.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">quadrature<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L87">interfaces.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L87">interfaces.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">unknown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;-1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L86">interfaces.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L86">interfaces.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.addpoint.html
+++ b/doc/interfaces/_corpus_.addpoint.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L393">corpus.ts:393</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L393">corpus.ts:393</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#addpointbodyitem" class="tsd-signature-type">AddPointBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L399">corpus.ts:399</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L399">corpus.ts:399</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L398">corpus.ts:398</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L398">corpus.ts:398</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"add_point"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L392">corpus.ts:392</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L392">corpus.ts:392</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.calibrate.html
+++ b/doc/interfaces/_corpus_.calibrate.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L329">corpus.ts:329</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L329">corpus.ts:329</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L333">corpus.ts:333</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L333">corpus.ts:333</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L332">corpus.ts:332</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L332">corpus.ts:332</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"calibrate"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L328">corpus.ts:328</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L328">corpus.ts:328</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.channel.html
+++ b/doc/interfaces/_corpus_.channel.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L89">corpus.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L89">corpus.ts:89</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L93">corpus.ts:93</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L93">corpus.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L92">corpus.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L92">corpus.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"channel"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L88">corpus.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L88">corpus.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.checkupdates.html
+++ b/doc/interfaces/_corpus_.checkupdates.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L227">corpus.ts:227</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L227">corpus.ts:227</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L231">corpus.ts:231</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L231">corpus.ts:231</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L230">corpus.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L230">corpus.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"check_updates"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L226">corpus.ts:226</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L226">corpus.ts:226</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.configupdate.html
+++ b/doc/interfaces/_corpus_.configupdate.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L352">corpus.ts:352</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L352">corpus.ts:352</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#configupdatebodyitem" class="tsd-signature-type">ConfigUpdateBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L356">corpus.ts:356</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L356">corpus.ts:356</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L355">corpus.ts:355</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L355">corpus.ts:355</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"config_update"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L351">corpus.ts:351</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L351">corpus.ts:351</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.coordinate.html
+++ b/doc/interfaces/_corpus_.coordinate.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L31">corpus.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L31">corpus.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L37">corpus.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L37">corpus.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L36">corpus.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L36">corpus.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"coordinate"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L30">corpus.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L30">corpus.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.dataupdate.html
+++ b/doc/interfaces/_corpus_.dataupdate.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L414">corpus.ts:414</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L414">corpus.ts:414</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#dataupdatebodyitem" class="tsd-signature-type">DataUpdateBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L420">corpus.ts:420</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L420">corpus.ts:420</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L419">corpus.ts:419</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L419">corpus.ts:419</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"data_update"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L413">corpus.ts:413</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L413">corpus.ts:413</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.emergencylock.html
+++ b/doc/interfaces/_corpus_.emergencylock.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L195">corpus.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L195">corpus.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L198">corpus.ts:198</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L198">corpus.ts:198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L197">corpus.ts:197</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L197">corpus.ts:197</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"emergency_lock"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L194">corpus.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L194">corpus.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.emergencyunlock.html
+++ b/doc/interfaces/_corpus_.emergencyunlock.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L203">corpus.ts:203</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L203">corpus.ts:203</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L206">corpus.ts:206</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L206">corpus.ts:206</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L205">corpus.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L205">corpus.ts:205</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"emergency_unlock"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L202">corpus.ts:202</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L202">corpus.ts:202</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.execute.html
+++ b/doc/interfaces/_corpus_.execute.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L119">corpus.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L119">corpus.ts:119</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L123">corpus.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L123">corpus.ts:123</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L122">corpus.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L122">corpus.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"execute"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L118">corpus.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L118">corpus.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.executescript.html
+++ b/doc/interfaces/_corpus_.executescript.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L372">corpus.ts:372</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L372">corpus.ts:372</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#executescriptbodyitem" class="tsd-signature-type">ExecuteScriptBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L376">corpus.ts:376</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L376">corpus.ts:376</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L375">corpus.ts:375</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L375">corpus.ts:375</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"execute_script"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L371">corpus.ts:371</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L371">corpus.ts:371</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.explanation.html
+++ b/doc/interfaces/_corpus_.explanation.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L261">corpus.ts:261</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L261">corpus.ts:261</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L265">corpus.ts:265</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L265">corpus.ts:265</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L264">corpus.ts:264</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L264">corpus.ts:264</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"explanation"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L260">corpus.ts:260</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L260">corpus.ts:260</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.factoryreset.html
+++ b/doc/interfaces/_corpus_.factoryreset.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L361">corpus.ts:361</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L361">corpus.ts:361</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L365">corpus.ts:365</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L365">corpus.ts:365</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L364">corpus.ts:364</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L364">corpus.ts:364</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"factory_reset"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L360">corpus.ts:360</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L360">corpus.ts:360</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.findhome.html
+++ b/doc/interfaces/_corpus_.findhome.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L176">corpus.ts:176</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L176">corpus.ts:176</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L181">corpus.ts:181</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L181">corpus.ts:181</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L180">corpus.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L180">corpus.ts:180</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"find_home"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L175">corpus.ts:175</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L175">corpus.ts:175</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.home.html
+++ b/doc/interfaces/_corpus_.home.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L166">corpus.ts:166</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L166">corpus.ts:166</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L171">corpus.ts:171</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L171">corpus.ts:171</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L170">corpus.ts:170</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L170">corpus.ts:170</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"home"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L165">corpus.ts:165</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L165">corpus.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.if.html
+++ b/doc/interfaces/_corpus_.if.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L130">corpus.ts:130</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L130">corpus.ts:130</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#ifbodyitem" class="tsd-signature-type">IfBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L140">corpus.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L140">corpus.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L139">corpus.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L139">corpus.ts:139</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"_if"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L129">corpus.ts:129</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L129">corpus.ts:129</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.installfarmware.html
+++ b/doc/interfaces/_corpus_.installfarmware.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L435">corpus.ts:435</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L435">corpus.ts:435</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L439">corpus.ts:439</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L439">corpus.ts:439</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L438">corpus.ts:438</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L438">corpus.ts:438</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"install_farmware"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L434">corpus.ts:434</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L434">corpus.ts:434</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.installfirstpartyfarmware.html
+++ b/doc/interfaces/_corpus_.installfirstpartyfarmware.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L462">corpus.ts:462</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L462">corpus.ts:462</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L465">corpus.ts:465</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L465">corpus.ts:465</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L464">corpus.ts:464</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L464">corpus.ts:464</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"install_first_party_farmware"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L461">corpus.ts:461</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L461">corpus.ts:461</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.moveabsolute.html
+++ b/doc/interfaces/_corpus_.moveabsolute.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L42">corpus.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L42">corpus.ts:42</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L50">corpus.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L50">corpus.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L49">corpus.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L49">corpus.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"move_absolute"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L41">corpus.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L41">corpus.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.moverelative.html
+++ b/doc/interfaces/_corpus_.moverelative.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L55">corpus.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L55">corpus.ts:55</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L62">corpus.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L62">corpus.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L61">corpus.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L61">corpus.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"move_relative"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L54">corpus.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L54">corpus.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.nothing.html
+++ b/doc/interfaces/_corpus_.nothing.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L14">corpus.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L14">corpus.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L17">corpus.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L17">corpus.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L16">corpus.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L16">corpus.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"nothing"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L13">corpus.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L13">corpus.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.pair.html
+++ b/doc/interfaces/_corpus_.pair.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L338">corpus.ts:338</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L338">corpus.ts:338</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L345">corpus.ts:345</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L345">corpus.ts:345</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L344">corpus.ts:344</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L344">corpus.ts:344</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"pair"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L337">corpus.ts:337</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L337">corpus.ts:337</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.point.html
+++ b/doc/interfaces/_corpus_.point.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L425">corpus.ts:425</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L425">corpus.ts:425</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L430">corpus.ts:430</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L430">corpus.ts:430</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L429">corpus.ts:429</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L429">corpus.ts:429</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"point"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L424">corpus.ts:424</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L424">corpus.ts:424</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.poweroff.html
+++ b/doc/interfaces/_corpus_.poweroff.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L236">corpus.ts:236</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L236">corpus.ts:236</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L239">corpus.ts:239</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L239">corpus.ts:239</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L238">corpus.ts:238</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L238">corpus.ts:238</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"power_off"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L235">corpus.ts:235</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L235">corpus.ts:235</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.readpin.html
+++ b/doc/interfaces/_corpus_.readpin.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L78">corpus.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L78">corpus.ts:78</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L84">corpus.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L84">corpus.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L83">corpus.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L83">corpus.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"read_pin"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L77">corpus.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L77">corpus.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.readstatus.html
+++ b/doc/interfaces/_corpus_.readstatus.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L211">corpus.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L211">corpus.ts:211</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L214">corpus.ts:214</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L214">corpus.ts:214</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L213">corpus.ts:213</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L213">corpus.ts:213</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"read_status"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L210">corpus.ts:210</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L210">corpus.ts:210</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.reboot.html
+++ b/doc/interfaces/_corpus_.reboot.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L244">corpus.ts:244</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L244">corpus.ts:244</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L247">corpus.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L247">corpus.ts:247</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L246">corpus.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L246">corpus.ts:246</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"reboot"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L243">corpus.ts:243</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L243">corpus.ts:243</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.removefarmware.html
+++ b/doc/interfaces/_corpus_.removefarmware.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L453">corpus.ts:453</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L453">corpus.ts:453</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L457">corpus.ts:457</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L457">corpus.ts:457</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L456">corpus.ts:456</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L456">corpus.ts:456</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"remove_farmware"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L452">corpus.ts:452</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L452">corpus.ts:452</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.rpcerror.html
+++ b/doc/interfaces/_corpus_.rpcerror.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L320">corpus.ts:320</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L320">corpus.ts:320</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#rpcerrorbodyitem" class="tsd-signature-type">RpcErrorBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L324">corpus.ts:324</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L324">corpus.ts:324</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L323">corpus.ts:323</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L323">corpus.ts:323</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"rpc_error"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L319">corpus.ts:319</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L319">corpus.ts:319</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.rpcok.html
+++ b/doc/interfaces/_corpus_.rpcok.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L309">corpus.ts:309</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L309">corpus.ts:309</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L313">corpus.ts:313</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L313">corpus.ts:313</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L312">corpus.ts:312</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L312">corpus.ts:312</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"rpc_ok"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L308">corpus.ts:308</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L308">corpus.ts:308</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.rpcrequest.html
+++ b/doc/interfaces/_corpus_.rpcrequest.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L300">corpus.ts:300</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L300">corpus.ts:300</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#rpcrequestbodyitem" class="tsd-signature-type">RpcRequestBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L304">corpus.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L304">corpus.ts:304</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L303">corpus.ts:303</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L303">corpus.ts:303</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"rpc_request"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L299">corpus.ts:299</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L299">corpus.ts:299</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.sendmessage.html
+++ b/doc/interfaces/_corpus_.sendmessage.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L109">corpus.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L109">corpus.ts:109</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#sendmessagebodyitem" class="tsd-signature-type">SendMessageBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L114">corpus.ts:114</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L114">corpus.ts:114</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L113">corpus.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L113">corpus.ts:113</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"send_message"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L108">corpus.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L108">corpus.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.sequence.html
+++ b/doc/interfaces/_corpus_.sequence.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L157">corpus.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L157">corpus.ts:157</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#sequencebodyitem" class="tsd-signature-type">SequenceBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L161">corpus.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L161">corpus.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L160">corpus.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L160">corpus.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"sequence"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L156">corpus.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L156">corpus.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.setuserenv.html
+++ b/doc/interfaces/_corpus_.setuserenv.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L383">corpus.ts:383</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L383">corpus.ts:383</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <a href="../modules/_corpus_.html#setuserenvbodyitem" class="tsd-signature-type">SetUserEnvBodyItem</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L386">corpus.ts:386</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L386">corpus.ts:386</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L385">corpus.ts:385</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L385">corpus.ts:385</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"set_user_env"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L382">corpus.ts:382</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L382">corpus.ts:382</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.sync.html
+++ b/doc/interfaces/_corpus_.sync.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L219">corpus.ts:219</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L219">corpus.ts:219</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L222">corpus.ts:222</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L222">corpus.ts:222</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L221">corpus.ts:221</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L221">corpus.ts:221</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"sync"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L218">corpus.ts:218</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L218">corpus.ts:218</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.takephoto.html
+++ b/doc/interfaces/_corpus_.takephoto.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">__type</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L404">corpus.ts:404</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L404">corpus.ts:404</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L407">corpus.ts:407</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L407">corpus.ts:407</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L406">corpus.ts:406</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L406">corpus.ts:406</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"take_photo"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L403">corpus.ts:403</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L403">corpus.ts:403</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.togglepin.html
+++ b/doc/interfaces/_corpus_.togglepin.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L252">corpus.ts:252</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L252">corpus.ts:252</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L256">corpus.ts:256</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L256">corpus.ts:256</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L255">corpus.ts:255</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L255">corpus.ts:255</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"toggle_pin"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L251">corpus.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L251">corpus.ts:251</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.tool.html
+++ b/doc/interfaces/_corpus_.tool.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L22">corpus.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L22">corpus.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L26">corpus.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L26">corpus.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L25">corpus.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L25">corpus.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"tool"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L21">corpus.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L21">corpus.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.updatefarmware.html
+++ b/doc/interfaces/_corpus_.updatefarmware.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L444">corpus.ts:444</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L444">corpus.ts:444</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L448">corpus.ts:448</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L448">corpus.ts:448</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L447">corpus.ts:447</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L447">corpus.ts:447</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"update_farmware"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L443">corpus.ts:443</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L443">corpus.ts:443</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.wait.html
+++ b/doc/interfaces/_corpus_.wait.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L98">corpus.ts:98</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L98">corpus.ts:98</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L102">corpus.ts:102</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L102">corpus.ts:102</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L101">corpus.ts:101</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L101">corpus.ts:101</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"wait"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L97">corpus.ts:97</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L97">corpus.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.writepin.html
+++ b/doc/interfaces/_corpus_.writepin.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L67">corpus.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L67">corpus.ts:67</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L73">corpus.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L73">corpus.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L72">corpus.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L72">corpus.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"write_pin"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L66">corpus.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L66">corpus.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_corpus_.zero.html
+++ b/doc/interfaces/_corpus_.zero.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L186">corpus.ts:186</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L186">corpus.ts:186</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L190">corpus.ts:190</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L190">corpus.ts:190</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">comment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L189">corpus.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L189">corpus.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"zero"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L185">corpus.ts:185</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L185">corpus.ts:185</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_interfaces_.apitoken.html
+++ b/doc/interfaces/_interfaces_.apitoken.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">bot<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L244">interfaces.ts:244</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L244">interfaces.ts:244</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">mqtt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L237">interfaces.ts:237</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L237">interfaces.ts:237</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">mqtt_<wbr>ws<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L241">interfaces.ts:241</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L241">interfaces.ts:241</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/doc/interfaces/_interfaces_.botstatetree.html
+++ b/doc/interfaces/_interfaces_.botstatetree.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">configuration<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#configuration" class="tsd-signature-type">Configuration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L10">interfaces.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L10">interfaces.ts:10</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">informational_<wbr>settings<span class="tsd-signature-symbol">:</span> <a href="_interfaces_.informationalsettings.html" class="tsd-signature-type">InformationalSettings</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L12">interfaces.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L12">interfaces.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">jobs<span class="tsd-signature-symbol">:</span> <a href="_interfaces_.dictionary.html" class="tsd-signature-type">Dictionary</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="_interfaces_.percentageprogress.html" class="tsd-signature-type">PercentageProgress</a><span class="tsd-signature-symbol"> | </span><a href="_interfaces_.bytesprogress.html" class="tsd-signature-type">BytesProgress</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L17">interfaces.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L17">interfaces.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">location_<wbr>data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_interfaces_.html#locationname" class="tsd-signature-type">LocationName</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_interfaces_.html#xyz" class="tsd-signature-type">Xyz</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L6">interfaces.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L6">interfaces.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">mcu_<wbr>params<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#mcuparams" class="tsd-signature-type">McuParams</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L4">interfaces.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L4">interfaces.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">pins<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#pins" class="tsd-signature-type">Pins</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L8">interfaces.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L8">interfaces.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">process_<wbr>info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L19">interfaces.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L19">interfaces.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">user_<wbr>env<span class="tsd-signature-symbol">:</span> <a href="_interfaces_.dictionary.html" class="tsd-signature-type">Dictionary</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L14">interfaces.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L14">interfaces.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/doc/interfaces/_interfaces_.bytesprogress.html
+++ b/doc/interfaces/_interfaces_.bytesprogress.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">bytes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L51">interfaces.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L51">interfaces.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#progressstatus" class="tsd-signature-type">ProgressStatus</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L49">interfaces.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L49">interfaces.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">unit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"bytes"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L50">interfaces.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L50">interfaces.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_interfaces_.constructorparams.html
+++ b/doc/interfaces/_interfaces_.constructorparams.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">secure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L226">interfaces.ts:226</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L226">interfaces.ts:226</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">speed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L230">interfaces.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L230">interfaces.ts:230</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">timeout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L228">interfaces.ts:228</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L228">interfaces.ts:228</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L224">interfaces.ts:224</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L224">interfaces.ts:224</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/doc/interfaces/_interfaces_.farmwaremanifest.html
+++ b/doc/interfaces/_interfaces_.farmwaremanifest.html
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">args<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L72">interfaces.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L72">interfaces.ts:72</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">config<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#farmwareconfig" class="tsd-signature-type">FarmwareConfig</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L77">interfaces.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L77">interfaces.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">executable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L69">interfaces.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L69">interfaces.ts:69</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">meta<span class="tsd-signature-symbol">:</span> <a href="_interfaces_.farmwaremanifestmeta.html" class="tsd-signature-type">FarmwareManifestMeta</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L76">interfaces.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L76">interfaces.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L73">interfaces.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L73">interfaces.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L75">interfaces.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L75">interfaces.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L74">interfaces.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L74">interfaces.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">uuid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L70">interfaces.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L70">interfaces.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_interfaces_.farmwaremanifestmeta.html
+++ b/doc/interfaces/_interfaces_.farmwaremanifestmeta.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">author<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L59">interfaces.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L59">interfaces.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L56">interfaces.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L56">interfaces.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">language<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L57">interfaces.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L57">interfaces.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">min_<wbr>os_<wbr>version_<wbr>major<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L55">interfaces.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L55">interfaces.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L58">interfaces.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L58">interfaces.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">zip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L60">interfaces.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L60">interfaces.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_interfaces_.fullconfiguration.html
+++ b/doc/interfaces/_interfaces_.fullconfiguration.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">firmware_<wbr>hardware<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#firmwarehardware" class="tsd-signature-type">FirmwareHardware</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L179">interfaces.ts:179</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L179">interfaces.ts:179</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">fw_<wbr>auto_<wbr>update<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L180">interfaces.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L180">interfaces.ts:180</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">os_<wbr>auto_<wbr>update<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L181">interfaces.ts:181</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L181">interfaces.ts:181</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">steps_<wbr>per_<wbr>mm_<wbr>x<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L182">interfaces.ts:182</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L182">interfaces.ts:182</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">steps_<wbr>per_<wbr>mm_<wbr>y<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L183">interfaces.ts:183</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L183">interfaces.ts:183</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">steps_<wbr>per_<wbr>mm_<wbr>z<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L184">interfaces.ts:184</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L184">interfaces.ts:184</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_interfaces_.informationalsettings.html
+++ b/doc/interfaces/_interfaces_.informationalsettings.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">busy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L212">interfaces.ts:212</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L212">interfaces.ts:212</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">controller_<wbr>version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L203">interfaces.ts:203</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L203">interfaces.ts:203</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">firmware_<wbr>version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L205">interfaces.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L205">interfaces.ts:205</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">locked<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L213">interfaces.ts:213</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L213">interfaces.ts:213</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">private_<wbr>ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L209">interfaces.ts:209</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L209">interfaces.ts:209</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync_<wbr>status<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#syncstatus" class="tsd-signature-type">SyncStatus</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L211">interfaces.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L211">interfaces.ts:211</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">throttled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L207">interfaces.ts:207</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L207">interfaces.ts:207</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/doc/interfaces/_interfaces_.percentageprogress.html
+++ b/doc/interfaces/_interfaces_.percentageprogress.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">percent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L45">interfaces.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L45">interfaces.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <a href="../modules/_interfaces_.html#progressstatus" class="tsd-signature-type">ProgressStatus</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L43">interfaces.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L43">interfaces.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">unit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"percent"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L44">interfaces.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L44">interfaces.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_interfaces_.pin.html
+++ b/doc/interfaces/_interfaces_.pin.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L172">interfaces.ts:172</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L172">interfaces.ts:172</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L173">interfaces.ts:173</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L173">interfaces.ts:173</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/interfaces/_interfaces_.processinfo.html
+++ b/doc/interfaces/_interfaces_.processinfo.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L81">interfaces.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L81">interfaces.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">uuid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L82">interfaces.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L82">interfaces.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/modules/_corpus_.html
+++ b/doc/modules/_corpus_.html
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALLOWED_<wbr>AXIS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"all"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L533">corpus.ts:533</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L533">corpus.ts:533</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALLOWED_<wbr>CHANNEL_<wbr>NAMES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"ticker"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"toast"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"email"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L521">corpus.ts:521</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L521">corpus.ts:521</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALLOWED_<wbr>DATA_<wbr>TYPES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"string"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"integer"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L524">corpus.ts:524</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L524">corpus.ts:524</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALLOWED_<wbr>MESSAGE_<wbr>TYPES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"success"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"busy"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"warn"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"error"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"info"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"fun"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L515">corpus.ts:515</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L515">corpus.ts:515</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALLOWED_<wbr>OPS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"&lt;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"&gt;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"is"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"not"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"is_undefined"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L526">corpus.ts:526</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L526">corpus.ts:526</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALLOWED_<wbr>PACKAGES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"farmbot_os"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"arduino_firmware"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L531">corpus.ts:531</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L531">corpus.ts:531</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">ALLOWED_<wbr>PIN_<wbr>MODES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L513">corpus.ts:513</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L513">corpus.ts:513</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<wbr>Point<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.pair.html" class="tsd-signature-type">Pair</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L389">corpus.ts:389</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L389">corpus.ts:389</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">Celery<wbr>Node<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.nothing.html" class="tsd-signature-type">Nothing</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.tool.html" class="tsd-signature-type">Tool</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.coordinate.html" class="tsd-signature-type">Coordinate</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.moveabsolute.html" class="tsd-signature-type">MoveAbsolute</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.moverelative.html" class="tsd-signature-type">MoveRelative</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.writepin.html" class="tsd-signature-type">WritePin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.readpin.html" class="tsd-signature-type">ReadPin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.channel.html" class="tsd-signature-type">Channel</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.wait.html" class="tsd-signature-type">Wait</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.sendmessage.html" class="tsd-signature-type">SendMessage</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.execute.html" class="tsd-signature-type">Execute</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.if.html" class="tsd-signature-type">If</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.sequence.html" class="tsd-signature-type">Sequence</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.home.html" class="tsd-signature-type">Home</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.findhome.html" class="tsd-signature-type">FindHome</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.zero.html" class="tsd-signature-type">Zero</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.emergencylock.html" class="tsd-signature-type">EmergencyLock</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.emergencyunlock.html" class="tsd-signature-type">EmergencyUnlock</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.readstatus.html" class="tsd-signature-type">ReadStatus</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.sync.html" class="tsd-signature-type">Sync</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.checkupdates.html" class="tsd-signature-type">CheckUpdates</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.poweroff.html" class="tsd-signature-type">PowerOff</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.reboot.html" class="tsd-signature-type">Reboot</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.togglepin.html" class="tsd-signature-type">TogglePin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.explanation.html" class="tsd-signature-type">Explanation</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.rpcrequest.html" class="tsd-signature-type">RpcRequest</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.rpcok.html" class="tsd-signature-type">RpcOk</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.rpcerror.html" class="tsd-signature-type">RpcError</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.calibrate.html" class="tsd-signature-type">Calibrate</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.pair.html" class="tsd-signature-type">Pair</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.configupdate.html" class="tsd-signature-type">ConfigUpdate</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.factoryreset.html" class="tsd-signature-type">FactoryReset</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.executescript.html" class="tsd-signature-type">ExecuteScript</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.setuserenv.html" class="tsd-signature-type">SetUserEnv</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.addpoint.html" class="tsd-signature-type">AddPoint</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.takephoto.html" class="tsd-signature-type">TakePhoto</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.dataupdate.html" class="tsd-signature-type">DataUpdate</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.point.html" class="tsd-signature-type">Point</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.installfarmware.html" class="tsd-signature-type">InstallFarmware</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.updatefarmware.html" class="tsd-signature-type">UpdateFarmware</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.removefarmware.html" class="tsd-signature-type">RemoveFarmware</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.installfirstpartyfarmware.html" class="tsd-signature-type">InstallFirstPartyFarmware</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L468">corpus.ts:468</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L468">corpus.ts:468</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"blue"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"green"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"yellow"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"orange"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"purple"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"pink"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"gray"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"red"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L537">corpus.ts:537</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L537">corpus.ts:537</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">Config<wbr>Update<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.pair.html" class="tsd-signature-type">Pair</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L348">corpus.ts:348</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L348">corpus.ts:348</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -276,7 +276,7 @@
 					<div class="tsd-signature tsd-kind-icon">Data<wbr>Change<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"add"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"remove"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"update"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L627">corpus.ts:627</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L627">corpus.ts:627</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<div class="tsd-signature tsd-kind-icon">Data<wbr>Update<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.pair.html" class="tsd-signature-type">Pair</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L410">corpus.ts:410</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L410">corpus.ts:410</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -296,7 +296,7 @@
 					<div class="tsd-signature tsd-kind-icon">Execute<wbr>Script<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.pair.html" class="tsd-signature-type">Pair</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L368">corpus.ts:368</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L368">corpus.ts:368</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -306,7 +306,7 @@
 					<div class="tsd-signature tsd-kind-icon">If<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.pair.html" class="tsd-signature-type">Pair</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L126">corpus.ts:126</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L126">corpus.ts:126</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -316,7 +316,7 @@
 					<div class="tsd-signature tsd-kind-icon">Legal<wbr>Arg<wbr>String<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"_else"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"_then"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"axis"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"channel_name"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"label"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"lhs"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"location"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"message"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"message_type"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"milliseconds"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"offset"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"op"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"package"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"pin_mode"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"pin_number"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"pin_value"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"pointer_id"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"pointer_type"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"radius"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"rhs"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"sequence_id"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"speed"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"tool_id"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"url"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"value"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"version"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"z"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L545">corpus.ts:545</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L545">corpus.ts:545</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -326,7 +326,7 @@
 					<div class="tsd-signature tsd-kind-icon">Legal<wbr>Kind<wbr>String<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"_if"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"add_point"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"calibrate"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"channel"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"check_updates"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"config_update"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"coordinate"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"data_update"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"emergency_lock"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"emergency_unlock"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"execute"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"execute_script"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"explanation"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"factory_reset"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"find_home"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"home"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"install_farmware"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"install_first_party_farmware"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"move_absolute"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"move_relative"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"nothing"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"pair"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"point"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"power_off"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"read_pin"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"read_status"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"reboot"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"remove_farmware"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"rpc_error"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"rpc_ok"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"rpc_request"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"send_message"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"sequence"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"set_user_env"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"sync"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"take_photo"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"toggle_pin"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"tool"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"update_farmware"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"wait"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"write_pin"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"zero"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L574">corpus.ts:574</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L574">corpus.ts:574</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -336,7 +336,7 @@
 					<div class="tsd-signature tsd-kind-icon">Legal<wbr>Sequence<wbr>Kind<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"_if"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"execute"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"execute_script"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"find_home"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"move_absolute"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"move_relative"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"read_pin"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"send_message"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"take_photo"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"wait"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"write_pin"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L616">corpus.ts:616</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L616">corpus.ts:616</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<div class="tsd-signature tsd-kind-icon">Point<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"GenericPointer"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"ToolSlot"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"Plant"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L644">corpus.ts:644</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L644">corpus.ts:644</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -356,7 +356,7 @@
 					<div class="tsd-signature tsd-kind-icon">Resource<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"images"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"plants"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"regimens"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"peripherals"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"corpuses"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"logs"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"sequences"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"farm_events"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"tool_slots"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"tools"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"points"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"tokens"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"users"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"device"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L630">corpus.ts:630</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L630">corpus.ts:630</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -366,7 +366,7 @@
 					<div class="tsd-signature tsd-kind-icon">Rpc<wbr>Error<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.explanation.html" class="tsd-signature-type">Explanation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L316">corpus.ts:316</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L316">corpus.ts:316</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">Rpc<wbr>Request<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.home.html" class="tsd-signature-type">Home</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.emergencylock.html" class="tsd-signature-type">EmergencyLock</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.emergencyunlock.html" class="tsd-signature-type">EmergencyUnlock</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.readstatus.html" class="tsd-signature-type">ReadStatus</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.sync.html" class="tsd-signature-type">Sync</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.checkupdates.html" class="tsd-signature-type">CheckUpdates</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.poweroff.html" class="tsd-signature-type">PowerOff</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.reboot.html" class="tsd-signature-type">Reboot</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.togglepin.html" class="tsd-signature-type">TogglePin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.configupdate.html" class="tsd-signature-type">ConfigUpdate</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.calibrate.html" class="tsd-signature-type">Calibrate</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.execute.html" class="tsd-signature-type">Execute</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.moveabsolute.html" class="tsd-signature-type">MoveAbsolute</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.moverelative.html" class="tsd-signature-type">MoveRelative</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.writepin.html" class="tsd-signature-type">WritePin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.readpin.html" class="tsd-signature-type">ReadPin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.sendmessage.html" class="tsd-signature-type">SendMessage</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.factoryreset.html" class="tsd-signature-type">FactoryReset</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.executescript.html" class="tsd-signature-type">ExecuteScript</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.setuserenv.html" class="tsd-signature-type">SetUserEnv</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.wait.html" class="tsd-signature-type">Wait</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.addpoint.html" class="tsd-signature-type">AddPoint</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.installfarmware.html" class="tsd-signature-type">InstallFarmware</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.updatefarmware.html" class="tsd-signature-type">UpdateFarmware</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.zero.html" class="tsd-signature-type">Zero</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.removefarmware.html" class="tsd-signature-type">RemoveFarmware</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.takephoto.html" class="tsd-signature-type">TakePhoto</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.dataupdate.html" class="tsd-signature-type">DataUpdate</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.findhome.html" class="tsd-signature-type">FindHome</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L268">corpus.ts:268</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L268">corpus.ts:268</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -386,7 +386,7 @@
 					<div class="tsd-signature tsd-kind-icon">Send<wbr>Message<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.channel.html" class="tsd-signature-type">Channel</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L105">corpus.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L105">corpus.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -396,7 +396,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sequence<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.moveabsolute.html" class="tsd-signature-type">MoveAbsolute</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.moverelative.html" class="tsd-signature-type">MoveRelative</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.writepin.html" class="tsd-signature-type">WritePin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.readpin.html" class="tsd-signature-type">ReadPin</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.wait.html" class="tsd-signature-type">Wait</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.sendmessage.html" class="tsd-signature-type">SendMessage</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.execute.html" class="tsd-signature-type">Execute</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.if.html" class="tsd-signature-type">If</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.executescript.html" class="tsd-signature-type">ExecuteScript</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.takephoto.html" class="tsd-signature-type">TakePhoto</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_corpus_.findhome.html" class="tsd-signature-type">FindHome</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L143">corpus.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L143">corpus.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -406,7 +406,7 @@
 					<div class="tsd-signature tsd-kind-icon">Set<wbr>User<wbr>Env<wbr>Body<wbr>Item<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_corpus_.pair.html" class="tsd-signature-type">Pair</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L379">corpus.ts:379</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L379">corpus.ts:379</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -419,7 +419,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANALOG<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">1</span><span class="tsd-signature-symbol"> =&nbsp;1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L512">corpus.ts:512</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L512">corpus.ts:512</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -429,7 +429,7 @@
 					<div class="tsd-signature tsd-kind-icon">DIGITAL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> =&nbsp;0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L511">corpus.ts:511</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L511">corpus.ts:511</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -439,7 +439,7 @@
 					<div class="tsd-signature tsd-kind-icon">LATEST_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">4</span><span class="tsd-signature-symbol"> =&nbsp;4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/corpus.ts#L510">corpus.ts:510</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/corpus.ts#L510">corpus.ts:510</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/modules/_farmbot_.html
+++ b/doc/modules/_farmbot_.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Primitive<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L19">farmbot.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L19">farmbot.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERR_<wbr>MISSING_<wbr>MQTT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"MQTT SERVER MISSING FROM TOKEN"</span><span class="tsd-signature-symbol"> =&nbsp;&quot;MQTT SERVER MISSING FROM TOKEN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L21">farmbot.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L21">farmbot.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERR_<wbr>MISSING_<wbr>UUID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"MISSING_UUID"</span><span class="tsd-signature-symbol"> =&nbsp;&quot;MISSING_UUID&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L22">farmbot.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L22">farmbot.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERR_<wbr>TOKEN_<wbr>PARSE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"Unable to parse token. Is it properly formatted?"</span><span class="tsd-signature-symbol"> =&nbsp;&quot;Unable to parse token. Is it properly formatted?&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L23">farmbot.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L23">farmbot.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">NULL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"null"</span><span class="tsd-signature-symbol"> =&nbsp;&quot;null&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L20">farmbot.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L20">farmbot.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">RECONNECT_<wbr>THROTTLE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">45000</span><span class="tsd-signature-symbol"> =&nbsp;45000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L30">farmbot.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L30">farmbot.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">UUID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"uuid"</span><span class="tsd-signature-symbol"> =&nbsp;&quot;uuid&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L24">farmbot.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L24">farmbot.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">atob<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">function</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L25">farmbot.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L25">farmbot.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/farmbot.ts#L26">farmbot.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/farmbot.ts#L26">farmbot.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/modules/_interfaces_.html
+++ b/doc/modules/_interfaces_.html
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">Configuration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_interfaces_.fullconfiguration.html" class="tsd-signature-type">FullConfiguration</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L187">interfaces.ts:187</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L187">interfaces.ts:187</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">Configuration<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"firmware_hardware"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"fw_auto_update"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"os_auto_update"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"steps_per_mm_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"steps_per_mm_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"steps_per_mm_z"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L189">interfaces.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L189">interfaces.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">Farmware<wbr>Config<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">"name"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"label"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"value"</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L63">interfaces.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L63">interfaces.ts:63</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">Firmware<wbr>Hardware<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"arduino"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"farmduino"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L24">interfaces.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L24">interfaces.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">Job<wbr>Progress<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_interfaces_.percentageprogress.html" class="tsd-signature-type">PercentageProgress</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_interfaces_.bytesprogress.html" class="tsd-signature-type">BytesProgress</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L38">interfaces.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L38">interfaces.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">Location<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"position"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"scaled_encoders"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"raw_encoders"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L28">interfaces.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L28">interfaces.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">MQTTEvent<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"connect"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"message"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L216">interfaces.ts:216</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L216">interfaces.ts:216</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mcu<wbr>Param<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"encoder_enabled_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_enabled_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_enabled_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_invert_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_invert_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_invert_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_missed_steps_decay_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_missed_steps_decay_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_missed_steps_decay_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_missed_steps_max_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_missed_steps_max_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_missed_steps_max_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_scaling_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_scaling_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_scaling_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_type_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_type_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_type_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_use_for_pos_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_use_for_pos_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"encoder_use_for_pos_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_axis_nr_steps_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_axis_nr_steps_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_axis_nr_steps_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_enable_endpoints_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_enable_endpoints_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_enable_endpoints_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_at_boot_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_at_boot_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_at_boot_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_spd_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_spd_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_spd_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_up_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_up_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_home_up_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_invert_endpoints_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_invert_endpoints_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_invert_endpoints_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_invert_motor_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_invert_motor_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_invert_motor_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_keep_active_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_keep_active_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_keep_active_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_max_spd_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_max_spd_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_max_spd_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_min_spd_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_min_spd_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_min_spd_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_secondary_motor_invert_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_secondary_motor_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_step_per_mm_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_step_per_mm_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_step_per_mm_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_steps_acc_dec_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_steps_acc_dec_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_steps_acc_dec_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_stop_at_home_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_stop_at_home_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_stop_at_home_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_stop_at_max_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_stop_at_max_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_stop_at_max_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_timeout_x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_timeout_y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"movement_timeout_z"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"param_e_stop_on_mov_err"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"param_mov_nr_retry"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"param_version"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L91">interfaces.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L91">interfaces.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mcu<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><a href="_interfaces_.html#mcuparamname" class="tsd-signature-type">McuParamName</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L165">interfaces.ts:165</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L165">interfaces.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pins<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_interfaces_.dictionary.html" class="tsd-signature-type">Dictionary</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_interfaces_.pin.html" class="tsd-signature-type">Pin</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L176">interfaces.ts:176</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L176">interfaces.ts:176</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">Progress<wbr>Status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"complete"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"working"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"error"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L33">interfaces.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L33">interfaces.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">State<wbr>Tree<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_interfaces_.dictionary.html" class="tsd-signature-type">Dictionary</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L220">interfaces.ts:220</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L220">interfaces.ts:220</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sync<wbr>Status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"locked"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"maintenance"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"sync_error"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"sync_now"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"synced"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"syncing"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"unknown"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L192">interfaces.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L192">interfaces.ts:192</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 					<div class="tsd-signature tsd-kind-icon">Vector3<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><a href="_interfaces_.html#xyz" class="tsd-signature-type">Xyz</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L169">interfaces.ts:169</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L169">interfaces.ts:169</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -279,7 +279,7 @@
 					<div class="tsd-signature tsd-kind-icon">Xyz<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"x"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"y"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"z"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/interfaces.ts#L167">interfaces.ts:167</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/interfaces.ts#L167">interfaces.ts:167</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/modules/_test_support_.html
+++ b/doc/modules/_test_support_.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">FAKE_<wbr>TOKEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZ&quot; +&quot;G1pbkBhZG1pbi5jb20iLCJpYXQiOjE1MDIxMjcxMTcsImp0aSI6IjlhZjY2NzJmLTY5NmEtNDh&quot; +&quot;lMy04ODVkLWJiZjEyZDlhYThjMiIsImlzcyI6Ii8vbG9jYWxob3N0OjMwMDAiLCJleHAiOjE1M&quot; +&quot;DU1ODMxMTcsIm1xdHQiOiJsb2NhbGhvc3QiLCJvc191cGRhdGVfc2VydmVyIjoiaHR0cHM6Ly9&quot; +&quot;hcGkuZ2l0aHViLmNvbS9yZXBvcy9mYXJtYm90L2Zhcm1ib3Rfb3MvcmVsZWFzZXMvbGF0ZXN0I&quot; +&quot;iwiZndfdXBkYXRlX3NlcnZlciI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvRmFybUJ&quot; +&quot;vdC9mYXJtYm90LWFyZHVpbm8tZmlybXdhcmUvcmVsZWFzZXMvbGF0ZXN0IiwiYm90IjoiZGV2a&quot; +&quot;WNlXzE1In0.XidSeTKp01ngtkHzKD_zklMVr9ZUHX-U_VDlwCSmNA8ahOHxkwCtx8a3o_McBWv&quot; +&quot;OYZN8RRzQVLlHJugHq1Vvw2KiUktK_1ABQ4-RuwxOyOBqqc11-6H_GbkM8dyzqRaWDnpTqHzkH&quot; +&quot;GxanoWVTTgGx2i_MZLr8FPZ8prnRdwC1x9zZ6xY7BtMPtHW0ddvMtXU8ZVF4CWJwKSaM0Q2pTx&quot; +&quot;I9GRqrp5Y8UjaKufif7bBPOUbkEHLNOiaux4MQr-OWAC8TrYMyFHzteXTEVkqw7rved84ogw6E&quot; +&quot;KBSFCVqwRA-NKWLpPMV_q7fRwiEGWj7R-KZqRweALXuvCLF765E6-ENxA&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/test_support.ts#L1">test_support.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/test_support.ts#L1">test_support.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/doc/modules/_util_.html
+++ b/doc/modules/_util_.html
@@ -98,7 +98,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L20">util.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L20">util.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L38">util.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L38">util.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L29">util.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L29">util.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L62">util.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L62">util.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L14">util.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L14">util.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -228,7 +228,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L42">util.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L42">util.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L50">util.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L50">util.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -274,7 +274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/b5323d8/src/util.ts#L4">util.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/RickCarlino/farmbot-js/blob/03c6313/src/util.ts#L4">util.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "farmbot",
-  "version": "5.0.1-rc9",
+  "version": "5.0.1-rc10",
   "description": "Farmbot Javascript client.",
   "scripts": {
     "build": "./build.sh",

--- a/src/farmbot.ts
+++ b/src/farmbot.ts
@@ -30,7 +30,7 @@ declare var global: typeof window;
 const RECONNECT_THROTTLE = 45000;
 
 export class Farmbot {
-  static VERSION = "5.0.1-rc9";
+  static VERSION = "5.0.1-rc10";
   static defaults = { speed: 800, timeout: 15000, secure: true };
 
   /** Storage area for all event handlers */
@@ -354,6 +354,7 @@ export class Farmbot {
    * acknowledge confirmation. Probably not the one you want. */
   publish(msg: Corpus.RpcRequest, important = true): void {
     if (this.client) {
+      this.emit("sent", msg);
       /** SEE: https://github.com/mqttjs/MQTT.js#client */
       this.client.publish(this.channel.toDevice, JSON.stringify(msg));
     } else {


### PR DESCRIPTION
# What's New?


 * a Farmbot object will now emit a `sent` event, which is useful for tracking when an RPC request has started.

Updates have been published to NPM.